### PR TITLE
Widget completeness & Restructuring

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,11 +47,7 @@ class _MyAppState extends State<MyApp> {
             ),
           ],
         ),
-        body: ListView(
-          children: const <Widget>[
-            MaterialShowcase(),
-          ],
-        ),
+        body: const MaterialShowcase(),
       ),
     );
   }

--- a/lib/components/bottom_navigation.dart
+++ b/lib/components/bottom_navigation.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseBottomNavigation extends StatefulWidget {
+  const MaterialShowcaseBottomNavigation({super.key});
+
+  @override
+  State<MaterialShowcaseBottomNavigation> createState() =>
+      _MaterialShowcaseBottomNavigationState();
+}
+
+class _MaterialShowcaseBottomNavigationState
+    extends State<MaterialShowcaseBottomNavigation> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: BottomNavigationBar(
+            currentIndex: _selectedIndex,
+            onTap: (index) => setState(() => _selectedIndex = index),
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home),
+                label: 'Home',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.business),
+                label: 'Business',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.school),
+                label: 'School',
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: NavigationBar(
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (index) =>
+                setState(() => _selectedIndex = index),
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.explore),
+                label: 'Explore',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.commute),
+                label: 'Commute',
+              ),
+              NavigationDestination(
+                selectedIcon: Icon(Icons.bookmark),
+                icon: Icon(Icons.bookmark_border),
+                label: 'Saved',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/buttons.dart
+++ b/lib/components/buttons.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseButtons extends StatelessWidget {
+  const MaterialShowcaseButtons({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        ElevatedButton(
+          onPressed: () {},
+          child: const Text('Elevated Button'),
+        ),
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Elevated with Icon'),
+        ),
+        FilledButton(
+          onPressed: () {},
+          child: const Text('Filled Button'),
+        ),
+        FilledButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Filled with Icon'),
+        ),
+        FilledButton.tonal(
+          onPressed: () {},
+          child: const Text('Filled Tonal'),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Tonal with Icon'),
+        ),
+        OutlinedButton(
+          onPressed: () {},
+          child: const Text('Outlined Button'),
+        ),
+        OutlinedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Outlined with Icon'),
+        ),
+        TextButton(
+          onPressed: () {},
+          child: const Text('Text Button'),
+        ),
+        TextButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Text with Icon'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/cards.dart
+++ b/lib/components/cards.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseCards extends StatelessWidget {
+  const MaterialShowcaseCards({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const ListTile(
+                  leading: Icon(Icons.album),
+                  title: Text('Basic Card'),
+                  subtitle: Text('With ListTile'),
+                ),
+                OverflowBar(
+                  children: [
+                    TextButton(
+                      onPressed: () {},
+                      child: const Text('ACTION 1'),
+                    ),
+                    TextButton(
+                      onPressed: () {},
+                      child: const Text('ACTION 2'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        Card(
+          elevation: 8,
+          child: Container(
+            width: 200,
+            height: 100,
+            padding: const EdgeInsets.all(16),
+            child: const Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.favorite),
+                Text('Elevated Card'),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/chips.dart
+++ b/lib/components/chips.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseChips extends StatelessWidget {
+  const MaterialShowcaseChips({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        Chip(
+          label: const Text('Basic Chip'),
+          onDeleted: () {},
+        ),
+        Chip(
+          avatar: const FlutterLogo(),
+          label: const Text('Avatar Chip'),
+          onDeleted: () {},
+        ),
+        Chip(
+          avatar: const Icon(Icons.person),
+          label: const Text('Icon Chip'),
+          deleteIcon: const Icon(Icons.cancel),
+          onDeleted: () {},
+        ),
+        InputChip(
+          label: const Text('Input Chip'),
+          onSelected: (_) {},
+        ),
+        InputChip(
+          avatar: const Icon(Icons.add),
+          label: const Text('Input with Icon'),
+          deleteIcon: const Icon(Icons.cancel),
+          onSelected: (_) {},
+        ),
+        RawChip(
+          label: const Text('Raw Chip'),
+          showCheckmark: true,
+          selected: true,
+          onSelected: (_) {},
+        ),
+        ActionChip(
+          avatar: const Icon(Icons.settings),
+          label: const Text('Action Chip'),
+          onPressed: () {},
+        ),
+        ChoiceChip(
+          label: const Text('Selected Chip'),
+          selected: true,
+          onSelected: (_) {},
+        ),
+        ChoiceChip(
+          avatar: const Icon(Icons.check),
+          label: const Text('With Icon'),
+          selected: true,
+          onSelected: (_) {},
+        ),
+        ChoiceChip(
+          label: const Text('Not Selected'),
+          selected: false,
+          onSelected: (_) {},
+        ),
+        ChoiceChip(
+          avatar: const Icon(Icons.close),
+          label: const Text('Not Selected Icon'),
+          selected: false,
+          onSelected: (_) {},
+        ),
+        FilterChip(
+          label: const Text('Filter Chip'),
+          selected: true,
+          onSelected: (_) {},
+        ),
+        FilterChip(
+          avatar: const Icon(Icons.filter_list),
+          label: const Text('Filter with Icon'),
+          onSelected: (_) {},
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/datetime_pickers.dart
+++ b/lib/components/datetime_pickers.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseDateTimePickers extends StatelessWidget {
+  const MaterialShowcaseDateTimePickers({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        Card(
+          child: CalendarDatePicker(
+            firstDate: DateTime(2019),
+            initialDate: DateTime.now(),
+            lastDate: DateTime.now().add(const Duration(days: 365)),
+            onDateChanged: (date) {},
+          ),
+        ),
+        Card(
+          child: TimePickerDialog(
+            initialTime: TimeOfDay.now(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/dialogs.dart
+++ b/lib/components/dialogs.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseDialogs extends StatelessWidget {
+  const MaterialShowcaseDialogs({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        SimpleDialog(
+          title: const Text('Simple Dialog'),
+          children: <Widget>[
+            SimpleDialogOption(
+              onPressed: () {},
+              child: const Text('Option 1'),
+            ),
+            SimpleDialogOption(
+              onPressed: () {},
+              child: const Text('Option 2'),
+            ),
+            const Divider(),
+            SimpleDialogOption(
+              onPressed: () {},
+              child: const Text('Cancel'),
+            ),
+          ],
+        ),
+        AlertDialog(
+          title: const Text('Alert Dialog'),
+          content: const Text('This is an alert dialog.'),
+          actions: [
+            TextButton(
+              onPressed: () {},
+              child: const Text('CANCEL'),
+            ),
+            TextButton(
+              onPressed: () {},
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/icon_buttons.dart
+++ b/lib/components/icon_buttons.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseIconButtons extends StatelessWidget {
+  const MaterialShowcaseIconButtons({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: <Widget>[
+        FloatingActionButton.small(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+        FloatingActionButton(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+        FloatingActionButton.large(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+        FloatingActionButton.extended(
+          onPressed: () {},
+          icon: const Icon(Icons.add),
+          label: const Text('Extended FAB'),
+        ),
+        IconButton(
+          icon: const Icon(Icons.favorite),
+          onPressed: () {},
+        ),
+        IconButton.filled(
+          icon: const Icon(Icons.favorite),
+          onPressed: () {},
+        ),
+        IconButton.filledTonal(
+          icon: const Icon(Icons.favorite),
+          onPressed: () {},
+        ),
+        IconButton.outlined(
+          icon: const Icon(Icons.favorite),
+          onPressed: () {},
+        ),
+        const CircleAvatar(
+          child: Text('AV'),
+        ),
+        const CircleAvatar(
+          backgroundColor: Colors.blue,
+          child: Icon(Icons.person),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/selection_controls.dart
+++ b/lib/components/selection_controls.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseSelectionControls extends StatefulWidget {
+  const MaterialShowcaseSelectionControls({super.key});
+
+  @override
+  State<MaterialShowcaseSelectionControls> createState() =>
+      _MaterialShowcaseSelectionControlsState();
+}
+
+class _MaterialShowcaseSelectionControlsState
+    extends State<MaterialShowcaseSelectionControls> {
+  bool _switchValue = false;
+  double _sliderValue = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        Checkbox(
+          value: true,
+          onChanged: (value) {},
+        ),
+        Checkbox(
+          value: false,
+          onChanged: (value) {},
+        ),
+        Checkbox(
+          value: null,
+          tristate: true,
+          onChanged: (value) {},
+        ),
+        Switch(
+          value: _switchValue,
+          onChanged: (value) => setState(() => _switchValue = value),
+        ),
+        Radio(
+          value: true,
+          groupValue: true,
+          onChanged: (value) {},
+        ),
+        Radio(
+          value: false,
+          groupValue: true,
+          onChanged: (value) {},
+        ),
+        Slider(
+          value: _sliderValue,
+          onChanged: (value) => setState(() => _sliderValue = value),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/showcase_section.dart
+++ b/lib/components/showcase_section.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class ExampleSection extends StatelessWidget {
+  const ExampleSection({
+    super.key,
+    required this.title,
+    required this.child,
+  });
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 20, top: 10),
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+        ),
+        const Divider(height: 10),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: child,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/showcase_section.dart
+++ b/lib/components/showcase_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class ExampleSection extends StatelessWidget {
-  const ExampleSection({
+class ShowcaseSection extends StatelessWidget {
+  const ShowcaseSection({
     super.key,
     required this.title,
     required this.child,

--- a/lib/components/tabs.dart
+++ b/lib/components/tabs.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseTabs extends StatelessWidget {
+  const MaterialShowcaseTabs({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Wrap(
+      spacing: 10,
+      children: <Widget>[
+        TabBar(
+          tabs: <Widget>[
+            Tab(
+              text: 'Tab 1',
+              icon: Icon(Icons.accessibility),
+            ),
+            Tab(
+              text: 'Tab 2',
+              icon: Icon(Icons.favorite),
+            ),
+            Tab(
+              text: 'Tab 3',
+              icon: Icon(Icons.person),
+            ),
+          ],
+        ),
+        SizedBox(height: 8),
+        TabBar(
+          isScrollable: true,
+          tabs: <Widget>[
+            Tab(text: 'Scrollable 1'),
+            Tab(text: 'Scrollable 2'),
+            Tab(text: 'Scrollable 3'),
+            Tab(text: 'Scrollable 4'),
+            Tab(text: 'Scrollable 5'),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/text_inputs.dart
+++ b/lib/components/text_inputs.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseTextInputs extends StatelessWidget {
+  const MaterialShowcaseTextInputs({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: TextEditingController(),
+            decoration: const InputDecoration(
+              labelText: 'Outlined TextField',
+              hintText: 'Enter text here',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.person),
+              suffixIcon: Icon(Icons.clear),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: TextEditingController(),
+            decoration: const InputDecoration(
+              labelText: 'Filled TextField',
+              hintText: 'Enter text here',
+              filled: true,
+              border: UnderlineInputBorder(),
+              prefixIcon: Icon(Icons.search),
+              suffixIcon: Icon(Icons.mic),
+            ),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: TextField(
+            decoration: InputDecoration(
+              labelText: 'Error TextField',
+              errorText: 'Error message',
+              border: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: TextField(
+            enabled: false,
+            decoration: InputDecoration(
+              labelText: 'Disabled TextField',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/texts.dart
+++ b/lib/components/texts.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class MaterialShowcaseTexts extends StatelessWidget {
+  const MaterialShowcaseTexts({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Display Large',
+          style: Theme.of(context).textTheme.displayLarge,
+        ),
+        Text(
+          'Display Medium',
+          style: Theme.of(context).textTheme.displayMedium,
+        ),
+        Text(
+          'Display Small',
+          style: Theme.of(context).textTheme.displaySmall,
+        ),
+        Text(
+          'Headline Large',
+          style: Theme.of(context).textTheme.headlineLarge,
+        ),
+        Text(
+          'Headline Medium',
+          style: Theme.of(context).textTheme.headlineMedium,
+        ),
+        Text(
+          'Headline Small',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        Text(
+          'Title Large',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        Text(
+          'Title Medium',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        Text(
+          'Title Small',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        Text(
+          'Body Large',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+        Text(
+          'Body Medium',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        Text(
+          'Body Small',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        Text(
+          'Label Large',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        Text(
+          'Label Medium',
+          style: Theme.of(context).textTheme.labelMedium,
+        ),
+        Text(
+          'Label Small',
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -28,54 +28,56 @@ class MaterialShowcase extends StatelessWidget {
   Widget build(BuildContext context) {
     return const DefaultTabController(
       length: 3,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          ExampleSection(
-            title: 'Buttons',
-            child: MaterialShowcaseButtons(),
-          ),
-          ExampleSection(
-            title: 'Icon Buttons',
-            child: MaterialShowcaseIconButtons(),
-          ),
-          ExampleSection(
-            title: 'Chips',
-            child: MaterialShowcaseChips(),
-          ),
-          ExampleSection(
-            title: 'Selection Controls',
-            child: MaterialShowcaseSelectionControls(),
-          ),
-          ExampleSection(
-            title: 'Text Inputs',
-            child: MaterialShowcaseTextInputs(),
-          ),
-          ExampleSection(
-            title: 'Tabs',
-            child: MaterialShowcaseTabs(),
-          ),
-          ExampleSection(
-            title: 'Bottom Navigation',
-            child: MaterialShowcaseBottomNavigation(),
-          ),
-          ExampleSection(
-            title: 'Cards',
-            child: MaterialShowcaseCards(),
-          ),
-          ExampleSection(
-            title: 'Date & Time Pickers',
-            child: MaterialShowcaseDateTimePickers(),
-          ),
-          ExampleSection(
-            title: 'Dialogs',
-            child: MaterialShowcaseDialogs(),
-          ),
-          ExampleSection(
-            title: 'Texts',
-            child: MaterialShowcaseTexts(),
-          ),
-        ],
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            ExampleSection(
+              title: 'Buttons',
+              child: MaterialShowcaseButtons(),
+            ),
+            ExampleSection(
+              title: 'Icon Buttons',
+              child: MaterialShowcaseIconButtons(),
+            ),
+            ExampleSection(
+              title: 'Chips',
+              child: MaterialShowcaseChips(),
+            ),
+            ExampleSection(
+              title: 'Selection Controls',
+              child: MaterialShowcaseSelectionControls(),
+            ),
+            ExampleSection(
+              title: 'Text Inputs',
+              child: MaterialShowcaseTextInputs(),
+            ),
+            ExampleSection(
+              title: 'Tabs',
+              child: MaterialShowcaseTabs(),
+            ),
+            ExampleSection(
+              title: 'Bottom Navigation',
+              child: MaterialShowcaseBottomNavigation(),
+            ),
+            ExampleSection(
+              title: 'Cards',
+              child: MaterialShowcaseCards(),
+            ),
+            ExampleSection(
+              title: 'Date & Time Pickers',
+              child: MaterialShowcaseDateTimePickers(),
+            ),
+            ExampleSection(
+              title: 'Dialogs',
+              child: MaterialShowcaseDialogs(),
+            ),
+            ExampleSection(
+              title: 'Texts',
+              child: MaterialShowcaseTexts(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -1,6 +1,18 @@
 library flutter_material_showcase;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_material_showcase/components/bottom_navigation.dart';
+import 'package:flutter_material_showcase/components/buttons.dart';
+import 'package:flutter_material_showcase/components/cards.dart';
+import 'package:flutter_material_showcase/components/chips.dart';
+import 'package:flutter_material_showcase/components/datetime_pickers.dart';
+import 'package:flutter_material_showcase/components/dialogs.dart';
+import 'package:flutter_material_showcase/components/icon_buttons.dart';
+import 'package:flutter_material_showcase/components/selection_controls.dart';
+import 'package:flutter_material_showcase/components/showcase_section.dart';
+import 'package:flutter_material_showcase/components/tabs.dart';
+import 'package:flutter_material_showcase/components/text_inputs.dart';
+import 'package:flutter_material_showcase/components/texts.dart';
 
 /// Material Design components showcase for Flutter apps
 ///
@@ -23,604 +35,56 @@ class MaterialShowcase extends StatefulWidget {
 }
 
 class _MaterialShowcaseState extends State<MaterialShowcase> {
-  final _controller1 = TextEditingController();
-  final _controller2 = TextEditingController();
-  bool _switchValue = false;
-  double _sliderValue = 0.5;
-  int _selectedIndex = 0;
-
-  @override
-  void dispose() {
-    _controller1.dispose();
-    _controller2.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
+    return const DefaultTabController(
       length: 3,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          _buildButtonRow(),
-          _buildIconButtonRow(),
-          _buildChipRow(),
-          _buildChoiceChipRow(),
-          _buildCheckboxRow(),
-          _buildTextInput(),
-          _buildTabRow(context),
-          _buildBottomNavigation(),
-          _buildCard(),
-          _buildCalendar(),
-          _buildDialog(),
-          _buildText(context),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildButtonRow() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 10,
-        runSpacing: 10,
-        children: <Widget>[
-          ElevatedButton(
-            onPressed: () {},
-            child: const Text('Elevated Button'),
-          ),
-          ElevatedButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Elevated with Icon'),
-          ),
-          FilledButton(
-            onPressed: () {},
-            child: const Text('Filled Button'),
-          ),
-          FilledButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Filled with Icon'),
-          ),
-          FilledButton.tonal(
-            onPressed: () {},
-            child: const Text('Filled Tonal'),
-          ),
-          FilledButton.tonalIcon(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Tonal with Icon'),
-          ),
-          OutlinedButton(
-            onPressed: () {},
-            child: const Text('Outlined Button'),
-          ),
-          OutlinedButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Outlined with Icon'),
-          ),
-          TextButton(
-            onPressed: () {},
-            child: const Text('Text Button'),
-          ),
-          TextButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Text with Icon'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildIconButtonRow() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 10,
-        runSpacing: 10,
-        children: <Widget>[
-          FloatingActionButton.small(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-          FloatingActionButton(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-          FloatingActionButton.large(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-          FloatingActionButton.extended(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Extended FAB'),
-          ),
-          IconButton(
-            icon: const Icon(Icons.favorite),
-            onPressed: () {},
-          ),
-          IconButton.filled(
-            icon: const Icon(Icons.favorite),
-            onPressed: () {},
-          ),
-          IconButton.filledTonal(
-            icon: const Icon(Icons.favorite),
-            onPressed: () {},
-          ),
-          IconButton.outlined(
-            icon: const Icon(Icons.favorite),
-            onPressed: () {},
-          ),
-          const CircleAvatar(
-            child: Text('AV'),
-          ),
-          const CircleAvatar(
-            backgroundColor: Colors.blue,
-            child: Icon(Icons.person),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildChipRow() {
-    return const Padding(
-      padding: EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: <Widget>[
-          Chip(
-            label: Text('Basic Chip'),
-          ),
-          Chip(
-            avatar: FlutterLogo(),
-            label: Text('Avatar Chip'),
-          ),
-          Chip(
-            avatar: Icon(Icons.person),
-            label: Text('Icon Chip'),
-            deleteIcon: Icon(Icons.cancel),
-            onDeleted: null,
-          ),
-          InputChip(
-            label: Text('Input Chip'),
-          ),
-          InputChip(
-            avatar: Icon(Icons.add),
-            label: Text('Input with Icon'),
-            deleteIcon: Icon(Icons.cancel),
-            onDeleted: null,
-          ),
-          RawChip(
-            label: Text('Raw Chip'),
-            showCheckmark: true,
-            selected: true,
-          ),
-          ActionChip(
-            avatar: Icon(Icons.settings),
-            label: Text('Action Chip'),
-            onPressed: null,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildChoiceChipRow() {
-    return const Padding(
-      padding: EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: <Widget>[
-          ChoiceChip(
-            label: Text('Selected Chip'),
-            selected: true,
-          ),
-          ChoiceChip(
-            avatar: Icon(Icons.check),
-            label: Text('With Icon'),
-            selected: true,
-          ),
-          ChoiceChip(
-            label: Text('Not Selected'),
-            selected: false,
-          ),
-          ChoiceChip(
-            avatar: Icon(Icons.close),
-            label: Text('Not Selected Icon'),
-            selected: false,
-          ),
-          FilterChip(
-            label: Text('Filter Chip'),
-            selected: true,
-            onSelected: null,
-          ),
-          FilterChip(
-            avatar: Icon(Icons.filter_list),
-            label: Text('Filter with Icon'),
-            selected: false,
-            onSelected: null,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCheckboxRow() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: <Widget>[
-          Checkbox(
-            value: true,
-            onChanged: (value) {},
-          ),
-          Checkbox(
-            value: false,
-            onChanged: (value) {},
-          ),
-          Checkbox(
-            value: null,
-            tristate: true,
-            onChanged: (value) {},
-          ),
-          Switch(
-            value: _switchValue,
-            onChanged: (value) => setState(() => _switchValue = value),
-          ),
-          Radio(
-            value: true,
-            groupValue: true,
-            onChanged: (value) {},
-          ),
-          Radio(
-            value: false,
-            groupValue: true,
-            onChanged: (value) {},
-          ),
-          Slider(
-            value: _sliderValue,
-            onChanged: (value) => setState(() => _sliderValue = value),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTextInput() {
-    return Column(
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: TextField(
-            controller: _controller1,
-            decoration: const InputDecoration(
-              labelText: 'Outlined TextField',
-              hintText: 'Enter text here',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.person),
-              suffixIcon: Icon(Icons.clear),
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: TextField(
-            controller: _controller2,
-            decoration: const InputDecoration(
-              labelText: 'Filled TextField',
-              hintText: 'Enter text here',
-              filled: true,
-              border: UnderlineInputBorder(),
-              prefixIcon: Icon(Icons.search),
-              suffixIcon: Icon(Icons.mic),
-            ),
-          ),
-        ),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: TextField(
-            decoration: InputDecoration(
-              labelText: 'Error TextField',
-              errorText: 'Error message',
-              border: OutlineInputBorder(
-                borderSide: BorderSide(color: Colors.red),
-              ),
-            ),
-          ),
-        ),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: TextField(
-            enabled: false,
-            decoration: InputDecoration(
-              labelText: 'Disabled TextField',
-              border: OutlineInputBorder(),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildTabRow(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: ColoredBox(
-        color: widget.tabBackgroundColor ?? Colors.black26,
-        child: const Column(
-          children: [
-            TabBar(
-              tabs: <Widget>[
-                Tab(
-                  text: 'Tab 1',
-                  icon: Icon(Icons.accessibility),
-                ),
-                Tab(
-                  text: 'Tab 2',
-                  icon: Icon(Icons.favorite),
-                ),
-                Tab(
-                  text: 'Tab 3',
-                  icon: Icon(Icons.person),
-                ),
-              ],
-            ),
-            SizedBox(height: 8),
-            TabBar(
-              isScrollable: true,
-              tabs: <Widget>[
-                Tab(text: 'Scrollable 1'),
-                Tab(text: 'Scrollable 2'),
-                Tab(text: 'Scrollable 3'),
-                Tab(text: 'Scrollable 4'),
-                Tab(text: 'Scrollable 5'),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBottomNavigation() {
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: BottomNavigationBar(
-            currentIndex: _selectedIndex,
-            onTap: (index) => setState(() => _selectedIndex = index),
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                icon: Icon(Icons.home),
-                label: 'Home',
-              ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.business),
-                label: 'Business',
-              ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.school),
-                label: 'School',
-              ),
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: NavigationBar(
-            selectedIndex: _selectedIndex,
-            onDestinationSelected: (index) =>
-                setState(() => _selectedIndex = index),
-            destinations: const [
-              NavigationDestination(
-                icon: Icon(Icons.explore),
-                label: 'Explore',
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.commute),
-                label: 'Commute',
-              ),
-              NavigationDestination(
-                selectedIcon: Icon(Icons.bookmark),
-                icon: Icon(Icons.bookmark_border),
-                label: 'Saved',
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildCard() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const ListTile(
-                    leading: Icon(Icons.album),
-                    title: Text('Basic Card'),
-                    subtitle: Text('With ListTile'),
-                  ),
-                  ButtonBar(
-                    children: [
-                      TextButton(
-                        onPressed: () {},
-                        child: const Text('ACTION 1'),
-                      ),
-                      TextButton(
-                        onPressed: () {},
-                        child: const Text('ACTION 2'),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-          Card(
-            elevation: 8,
-            child: Container(
-              width: 200,
-              height: 100,
-              padding: const EdgeInsets.all(16),
-              child: const Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.favorite),
-                  Text('Elevated Card'),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCalendar() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Card(
-        child: CalendarDatePicker(
-          firstDate: DateTime(2019),
-          initialDate: DateTime.now(),
-          lastDate: DateTime.now().add(const Duration(days: 365)),
-          onDateChanged: (date) {},
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDialog() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          SimpleDialog(
-            title: const Text('Simple Dialog'),
-            children: <Widget>[
-              SimpleDialogOption(
-                onPressed: () {},
-                child: const Text('Option 1'),
-              ),
-              SimpleDialogOption(
-                onPressed: () {},
-                child: const Text('Option 2'),
-              ),
-              const Divider(),
-              SimpleDialogOption(
-                onPressed: () {},
-                child: const Text('Cancel'),
-              ),
-            ],
-          ),
-          AlertDialog(
-            title: const Text('Alert Dialog'),
-            content: const Text('This is an alert dialog.'),
-            actions: [
-              TextButton(
-                onPressed: () {},
-                child: const Text('CANCEL'),
-              ),
-              TextButton(
-                onPressed: () {},
-                child: const Text('OK'),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildText(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            'Display Large',
-            style: Theme.of(context).textTheme.displayLarge,
-          ),
-          Text(
-            'Display Medium',
-            style: Theme.of(context).textTheme.displayMedium,
-          ),
-          Text(
-            'Display Small',
-            style: Theme.of(context).textTheme.displaySmall,
-          ),
-          Text(
-            'Headline Large',
-            style: Theme.of(context).textTheme.headlineLarge,
-          ),
-          Text(
-            'Headline Medium',
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
-          Text(
-            'Headline Small',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          Text(
-            'Title Large',
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          Text(
-            'Title Medium',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          Text(
-            'Title Small',
-            style: Theme.of(context).textTheme.titleSmall,
-          ),
-          Text(
-            'Body Large',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-          Text(
-            'Body Medium',
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          Text(
-            'Body Small',
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-          Text(
-            'Label Large',
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
-          Text(
-            'Label Medium',
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-          Text(
-            'Label Small',
-            style: Theme.of(context).textTheme.labelSmall,
+          ExampleSection(
+            title: 'Buttons',
+            child: MaterialShowcaseButtons(),
+          ),
+          ExampleSection(
+            title: 'Icon Buttons',
+            child: MaterialShowcaseIconButtons(),
+          ),
+          ExampleSection(
+            title: 'Chips',
+            child: MaterialShowcaseChips(),
+          ),
+          ExampleSection(
+            title: 'Selection Controls',
+            child: MaterialShowcaseSelectionControls(),
+          ),
+          ExampleSection(
+            title: 'Text Inputs',
+            child: MaterialShowcaseTextInputs(),
+          ),
+          ExampleSection(
+            title: 'Tabs',
+            child: MaterialShowcaseTabs(),
+          ),
+          ExampleSection(
+            title: 'Bottom Navigation',
+            child: MaterialShowcaseBottomNavigation(),
+          ),
+          ExampleSection(
+            title: 'Cards',
+            child: MaterialShowcaseCards(),
+          ),
+          ExampleSection(
+            title: 'Date & Time Pickers',
+            child: MaterialShowcaseDateTimePickers(),
+          ),
+          ExampleSection(
+            title: 'Dialogs',
+            child: MaterialShowcaseDialogs(),
+          ),
+          ExampleSection(
+            title: 'Texts',
+            child: MaterialShowcaseTexts(),
           ),
         ],
       ),

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -32,47 +32,47 @@ class MaterialShowcase extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            ExampleSection(
+            ShowcaseSection(
               title: 'Buttons',
               child: MaterialShowcaseButtons(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Icon Buttons',
               child: MaterialShowcaseIconButtons(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Chips',
               child: MaterialShowcaseChips(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Selection Controls',
               child: MaterialShowcaseSelectionControls(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Text Inputs',
               child: MaterialShowcaseTextInputs(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Tabs',
               child: MaterialShowcaseTabs(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Bottom Navigation',
               child: MaterialShowcaseBottomNavigation(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Cards',
               child: MaterialShowcaseCards(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Date & Time Pickers',
               child: MaterialShowcaseDateTimePickers(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Dialogs',
               child: MaterialShowcaseDialogs(),
             ),
-            ExampleSection(
+            ShowcaseSection(
               title: 'Texts',
               child: MaterialShowcaseTexts(),
             ),

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -8,30 +8,32 @@ import 'package:flutter/material.dart';
 /// how it looks like with different Material Widgets.
 ///
 /// The [tabBackgroundColor] will default to [Colors.black26] if not set.
-///
 class MaterialShowcase extends StatefulWidget {
   /// Creates a MaterialShowcase
   const MaterialShowcase({
-    Key? key,
+    super.key,
     this.tabBackgroundColor,
-  }) : super(key: key);
+  });
 
   /// Color to be used under the TabBar
   final Color? tabBackgroundColor;
 
   @override
-  _MaterialShowcaseState createState() => _MaterialShowcaseState();
+  State<MaterialShowcase> createState() => _MaterialShowcaseState();
 }
 
 class _MaterialShowcaseState extends State<MaterialShowcase> {
   final _controller1 = TextEditingController();
   final _controller2 = TextEditingController();
+  bool _switchValue = false;
+  double _sliderValue = 0.5;
+  int _selectedIndex = 0;
 
   @override
   void dispose() {
-    super.dispose();
     _controller1.dispose();
     _controller2.dispose();
+    super.dispose();
   }
 
   @override
@@ -58,187 +60,239 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
     );
   }
 
-  Widget _buildTabRow(context) {
+  Widget _buildButtonRow() {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: ColoredBox(
-        color: widget.tabBackgroundColor ?? Colors.black26,
-        child: const TabBar(
-          tabs: <Widget>[
-            Tab(
-              text: 'Tab 1',
-              icon: Icon(Icons.accessibility),
-            ),
-            Tab(
-              text: 'Tab 2',
-              icon: Icon(Icons.accessibility),
-            ),
-            Tab(
-              text: 'Tab 3',
-              icon: Icon(Icons.accessibility),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Row _buildCheckboxRow() {
-    return Row(
-      children: <Widget>[
-        Checkbox(
-          value: true,
-          onChanged: (value) {},
-        ),
-        Checkbox(
-          value: false,
-          onChanged: (value) {},
-        ),
-        Radio(
-          value: true,
-          groupValue: true,
-          onChanged: (value) {},
-        ),
-        Radio(
-          value: false,
-          groupValue: false,
-          onChanged: (value) {},
-        ),
-      ],
-    );
-  }
-
-  Row _buildChoiceChipRow() {
-    return const Row(
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: ChoiceChip(
-            label: Text('Selected Chip'),
-            selected: true,
-          ),
-        ),
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: ChoiceChip(
-            label: Text('Not Selected Chip'),
-            selected: false,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Row _buildChipRow() {
-    return const Row(
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Chip(
-            label: Text('Chip'),
-          ),
-        ),
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Chip(
-            label: Text('Avatar Chip'),
-            avatar: FlutterLogo(),
-          ),
-        ),
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: InputChip(
-            label: Text('Input Chip'),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Row _buildIconButtonRow() {
-    return Row(
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: FloatingActionButton(
+      child: Wrap(
+        spacing: 10,
+        runSpacing: 10,
+        children: <Widget>[
+          ElevatedButton(
             onPressed: () {},
-            child: const Icon(Icons.accessibility),
+            child: const Text('Elevated Button'),
           ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: IconButton(
-            icon: const Icon(Icons.accessibility),
+          ElevatedButton.icon(
             onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Elevated with Icon'),
           ),
-        ),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: CircleAvatar(
-            child: Text('AV'),
+          FilledButton(
+            onPressed: () {},
+            child: const Text('Filled Button'),
           ),
-        ),
-      ],
-    );
-  }
-
-  Row _buildButtonRow() {
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ElevatedButton(
-              onPressed: () {},
-              child: const Text('Elevated Button'),
-            ),
+          FilledButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Filled with Icon'),
           ),
-        ),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextButton(
-              onPressed: () {},
-              child: const Text('Text Button'),
-            ),
+          FilledButton.tonal(
+            onPressed: () {},
+            child: const Text('Filled Tonal'),
           ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildBottomNavigation() {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: BottomNavigationBar(
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.accessibility),
-            label: 'Item 1',
+          FilledButton.tonalIcon(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Tonal with Icon'),
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.accessibility),
-            label: 'Item 2',
+          OutlinedButton(
+            onPressed: () {},
+            child: const Text('Outlined Button'),
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.accessibility),
-            label: 'Item 3',
+          OutlinedButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Outlined with Icon'),
+          ),
+          TextButton(
+            onPressed: () {},
+            child: const Text('Text Button'),
+          ),
+          TextButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Text with Icon'),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildCard() {
+  Widget _buildIconButtonRow() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 10,
+        runSpacing: 10,
+        children: <Widget>[
+          FloatingActionButton.small(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+          FloatingActionButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+          FloatingActionButton.large(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+          FloatingActionButton.extended(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Extended FAB'),
+          ),
+          IconButton(
+            icon: const Icon(Icons.favorite),
+            onPressed: () {},
+          ),
+          IconButton.filled(
+            icon: const Icon(Icons.favorite),
+            onPressed: () {},
+          ),
+          IconButton.filledTonal(
+            icon: const Icon(Icons.favorite),
+            onPressed: () {},
+          ),
+          IconButton.outlined(
+            icon: const Icon(Icons.favorite),
+            onPressed: () {},
+          ),
+          const CircleAvatar(
+            child: Text('AV'),
+          ),
+          const CircleAvatar(
+            backgroundColor: Colors.blue,
+            child: Icon(Icons.person),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChipRow() {
     return const Padding(
       padding: EdgeInsets.all(8.0),
-      child: Card(
-        child: SizedBox(
-          height: 100,
-          child: Center(
-            child: Text('Material Card'),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: <Widget>[
+          Chip(
+            label: Text('Basic Chip'),
           ),
-        ),
+          Chip(
+            avatar: FlutterLogo(),
+            label: Text('Avatar Chip'),
+          ),
+          Chip(
+            avatar: Icon(Icons.person),
+            label: Text('Icon Chip'),
+            deleteIcon: Icon(Icons.cancel),
+            onDeleted: null,
+          ),
+          InputChip(
+            label: Text('Input Chip'),
+          ),
+          InputChip(
+            avatar: Icon(Icons.add),
+            label: Text('Input with Icon'),
+            deleteIcon: Icon(Icons.cancel),
+            onDeleted: null,
+          ),
+          RawChip(
+            label: Text('Raw Chip'),
+            showCheckmark: true,
+            selected: true,
+          ),
+          ActionChip(
+            avatar: Icon(Icons.settings),
+            label: Text('Action Chip'),
+            onPressed: null,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChoiceChipRow() {
+    return const Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: <Widget>[
+          ChoiceChip(
+            label: Text('Selected Chip'),
+            selected: true,
+          ),
+          ChoiceChip(
+            avatar: Icon(Icons.check),
+            label: Text('With Icon'),
+            selected: true,
+          ),
+          ChoiceChip(
+            label: Text('Not Selected'),
+            selected: false,
+          ),
+          ChoiceChip(
+            avatar: Icon(Icons.close),
+            label: Text('Not Selected Icon'),
+            selected: false,
+          ),
+          FilterChip(
+            label: Text('Filter Chip'),
+            selected: true,
+            onSelected: null,
+          ),
+          FilterChip(
+            avatar: Icon(Icons.filter_list),
+            label: Text('Filter with Icon'),
+            selected: false,
+            onSelected: null,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCheckboxRow() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: <Widget>[
+          Checkbox(
+            value: true,
+            onChanged: (value) {},
+          ),
+          Checkbox(
+            value: false,
+            onChanged: (value) {},
+          ),
+          Checkbox(
+            value: null,
+            tristate: true,
+            onChanged: (value) {},
+          ),
+          Switch(
+            value: _switchValue,
+            onChanged: (value) => setState(() => _switchValue = value),
+          ),
+          Radio(
+            value: true,
+            groupValue: true,
+            onChanged: (value) {},
+          ),
+          Radio(
+            value: false,
+            groupValue: true,
+            onChanged: (value) {},
+          ),
+          Slider(
+            value: _sliderValue,
+            onChanged: (value) => setState(() => _sliderValue = value),
+          ),
+        ],
       ),
     );
   }
@@ -249,21 +303,49 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
         Padding(
           padding: const EdgeInsets.all(8.0),
           child: TextField(
-            key: const Key('TextField1'),
             controller: _controller1,
             decoration: const InputDecoration(
-              hintText: 'An Outline Border TextField',
+              labelText: 'Outlined TextField',
+              hintText: 'Enter text here',
               border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.person),
+              suffixIcon: Icon(Icons.clear),
             ),
           ),
         ),
         Padding(
           padding: const EdgeInsets.all(8.0),
           child: TextField(
-            key: const Key('TextField2'),
             controller: _controller2,
             decoration: const InputDecoration(
-              hintText: 'A TextField',
+              labelText: 'Filled TextField',
+              hintText: 'Enter text here',
+              filled: true,
+              border: UnderlineInputBorder(),
+              prefixIcon: Icon(Icons.search),
+              suffixIcon: Icon(Icons.mic),
+            ),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: TextField(
+            decoration: InputDecoration(
+              labelText: 'Error TextField',
+              errorText: 'Error message',
+              border: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: TextField(
+            enabled: false,
+            decoration: InputDecoration(
+              labelText: 'Disabled TextField',
+              border: OutlineInputBorder(),
             ),
           ),
         ),
@@ -271,27 +353,206 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
     );
   }
 
+  Widget _buildTabRow(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: ColoredBox(
+        color: widget.tabBackgroundColor ?? Colors.black26,
+        child: const Column(
+          children: [
+            TabBar(
+              tabs: <Widget>[
+                Tab(
+                  text: 'Tab 1',
+                  icon: Icon(Icons.accessibility),
+                ),
+                Tab(
+                  text: 'Tab 2',
+                  icon: Icon(Icons.favorite),
+                ),
+                Tab(
+                  text: 'Tab 3',
+                  icon: Icon(Icons.person),
+                ),
+              ],
+            ),
+            SizedBox(height: 8),
+            TabBar(
+              isScrollable: true,
+              tabs: <Widget>[
+                Tab(text: 'Scrollable 1'),
+                Tab(text: 'Scrollable 2'),
+                Tab(text: 'Scrollable 3'),
+                Tab(text: 'Scrollable 4'),
+                Tab(text: 'Scrollable 5'),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBottomNavigation() {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: BottomNavigationBar(
+            currentIndex: _selectedIndex,
+            onTap: (index) => setState(() => _selectedIndex = index),
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home),
+                label: 'Home',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.business),
+                label: 'Business',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.school),
+                label: 'School',
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: NavigationBar(
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (index) =>
+                setState(() => _selectedIndex = index),
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.explore),
+                label: 'Explore',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.commute),
+                label: 'Commute',
+              ),
+              NavigationDestination(
+                selectedIcon: Icon(Icons.bookmark),
+                icon: Icon(Icons.bookmark_border),
+                label: 'Saved',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCard() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const ListTile(
+                    leading: Icon(Icons.album),
+                    title: Text('Basic Card'),
+                    subtitle: Text('With ListTile'),
+                  ),
+                  ButtonBar(
+                    children: [
+                      TextButton(
+                        onPressed: () {},
+                        child: const Text('ACTION 1'),
+                      ),
+                      TextButton(
+                        onPressed: () {},
+                        child: const Text('ACTION 2'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Card(
+            elevation: 8,
+            child: Container(
+              width: 200,
+              height: 100,
+              padding: const EdgeInsets.all(16),
+              child: const Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.favorite),
+                  Text('Elevated Card'),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildCalendar() {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: CalendarDatePicker(
-        firstDate: DateTime(2019),
-        initialDate: DateTime.now(),
-        lastDate: DateTime.now().add(const Duration(days: 5)),
-        onDateChanged: (date) {},
+      child: Card(
+        child: CalendarDatePicker(
+          firstDate: DateTime(2019),
+          initialDate: DateTime.now(),
+          lastDate: DateTime.now().add(const Duration(days: 365)),
+          onDateChanged: (date) {},
+        ),
       ),
     );
   }
 
   Widget _buildDialog() {
-    return SimpleDialog(
-      title: const Text('Title'),
-      children: <Widget>[
-        SimpleDialogOption(
-          onPressed: () {},
-          child: const Text('SimpleDialogOption'),
-        ),
-      ],
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          SimpleDialog(
+            title: const Text('Simple Dialog'),
+            children: <Widget>[
+              SimpleDialogOption(
+                onPressed: () {},
+                child: const Text('Option 1'),
+              ),
+              SimpleDialogOption(
+                onPressed: () {},
+                child: const Text('Option 2'),
+              ),
+              const Divider(),
+              SimpleDialogOption(
+                onPressed: () {},
+                child: const Text('Cancel'),
+              ),
+            ],
+          ),
+          AlertDialog(
+            title: const Text('Alert Dialog'),
+            content: const Text('This is an alert dialog.'),
+            actions: [
+              TextButton(
+                onPressed: () {},
+                child: const Text('CANCEL'),
+              ),
+              TextButton(
+                onPressed: () {},
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
@@ -301,6 +562,18 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
+          Text(
+            'Display Large',
+            style: Theme.of(context).textTheme.displayLarge,
+          ),
+          Text(
+            'Display Medium',
+            style: Theme.of(context).textTheme.displayMedium,
+          ),
+          Text(
+            'Display Small',
+            style: Theme.of(context).textTheme.displaySmall,
+          ),
           Text(
             'Headline Large',
             style: Theme.of(context).textTheme.headlineLarge,
@@ -326,18 +599,6 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
             style: Theme.of(context).textTheme.titleSmall,
           ),
           Text(
-            'Label Large',
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
-          Text(
-            'Label Medium',
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-          Text(
-            'Label Small',
-            style: Theme.of(context).textTheme.labelSmall,
-          ),
-          Text(
             'Body Large',
             style: Theme.of(context).textTheme.bodyLarge,
           ),
@@ -348,6 +609,18 @@ class _MaterialShowcaseState extends State<MaterialShowcase> {
           Text(
             'Body Small',
             style: Theme.of(context).textTheme.bodySmall,
+          ),
+          Text(
+            'Label Large',
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+          Text(
+            'Label Medium',
+            style: Theme.of(context).textTheme.labelMedium,
+          ),
+          Text(
+            'Label Small',
+            style: Theme.of(context).textTheme.labelSmall,
           ),
         ],
       ),

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -20,21 +20,10 @@ import 'package:flutter_material_showcase/components/texts.dart';
 /// how it looks like with different Material Widgets.
 ///
 /// The [tabBackgroundColor] will default to [Colors.black26] if not set.
-class MaterialShowcase extends StatefulWidget {
+class MaterialShowcase extends StatelessWidget {
   /// Creates a MaterialShowcase
-  const MaterialShowcase({
-    super.key,
-    this.tabBackgroundColor,
-  });
+  const MaterialShowcase({super.key});
 
-  /// Color to be used under the TabBar
-  final Color? tabBackgroundColor;
-
-  @override
-  State<MaterialShowcase> createState() => _MaterialShowcaseState();
-}
-
-class _MaterialShowcaseState extends State<MaterialShowcase> {
   @override
   Widget build(BuildContext context) {
     return const DefaultTabController(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 homepage: https://github.com/miquelbeltran/flutter_material_showcase
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR Introduces following changes:

**Changelog:**

- Added more of widgets in each section for completeness
- Separated widgets sections into individual files for improved organisation and reusability
  - Each section now becomes reusable, so that if one wants, they can add only that section in their app for preview, instead of entire showcase
- Introduced a common layer for each section
- Added `SingleChildScrollView` as parent of `MaterialShowcase` widget, as it was anyways required in any place it's used
- Converted `MaterialShowcase` widget to a stateless widget for optimized performance

**Preview:**
| | | | |
|--------|--------|--------|--------|
| ![Screenshot_20241028_234309](https://github.com/user-attachments/assets/96ec5234-cf81-4127-9087-825eaf6cff63) | ![Screenshot_20241028_234323](https://github.com/user-attachments/assets/a2dceb3a-4887-44d9-b457-8ef91fcdb21e) | ![Screenshot_20241028_234333](https://github.com/user-attachments/assets/fa22df58-c42c-4718-836d-088c91bd9467) | ![Screenshot_20241028_234343](https://github.com/user-attachments/assets/38f29b57-41d5-472c-b229-30f443d55b8a) |
| ![Screenshot_20241028_234353](https://github.com/user-attachments/assets/b18d8cbd-fdf2-4345-a5fa-760717627a25) | ![Screenshot_20241028_234406](https://github.com/user-attachments/assets/24aa04fb-34f8-46f7-b55e-729652a9d6e4) | ![Screenshot_20241028_234411](https://github.com/user-attachments/assets/e4b245f1-037a-47d0-96d7-d50d64afd50b)
 | |