### PR TITLE
Add custom widgets to showcase

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:example/widgets/custom_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_material_showcase/components/showcase_section.dart';
 import 'package:flutter_material_showcase/flutter_material_showcase.dart';
 
 void main() => runApp(MyApp());
@@ -47,7 +49,14 @@ class _MyAppState extends State<MyApp> {
             ),
           ],
         ),
-        body: const MaterialShowcase(),
+        body: const MaterialShowcase(
+          customSections: [
+            MaterialShowcaseSection(
+              title: 'Custom Widget Section 1',
+              child: CustomWidget(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/example/lib/widgets/custom_widget.dart
+++ b/example/lib/widgets/custom_widget.dart
@@ -1,0 +1,138 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class CustomWidget extends StatefulWidget {
+  const CustomWidget({Key? key}) : super(key: key);
+
+  @override
+  State<CustomWidget> createState() => _CustomWidgetState();
+}
+
+class _CustomWidgetState extends State<CustomWidget> {
+  // Icons definition
+  static const IconData hiddenIcon = Icons.code;
+  static const IconData codeIcon = Icons.check_circle_outline;
+  static const IconData bugIcon = Icons.bug_report;
+  late final Color selectedColor;
+  late final Color unselectedColor;
+  late final Color bugColor;
+
+  // Game state
+  late List<bool> _isRevealed;
+  late int _bugPosition;
+  late bool _gameOver;
+
+  @override
+  void initState() {
+    super.initState();
+    _setupGame();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // Initialize colors here since we need context
+    selectedColor = Theme.of(context).colorScheme.primary;
+    unselectedColor = Theme.of(context).disabledColor;
+    bugColor = Theme.of(context).colorScheme.error;
+  }
+
+  void _setupGame() {
+    // Initialize 8 cells (2 rows x 4 columns)
+    _isRevealed = List.generate(8, (_) => false);
+    // Randomly place 1 bug
+    _bugPosition = Random().nextInt(8);
+    _gameOver = false;
+  }
+
+  void _handleCellTap(int index) {
+    if (_gameOver || _isRevealed[index]) return;
+
+    setState(() {
+      _isRevealed[index] = true;
+
+      if (index == _bugPosition) {
+        // If bug is found, reveal it
+        _gameOver = true;
+
+        // Schedule game reset after a delay
+        Future.delayed(const Duration(seconds: 2), () {
+          if (mounted) {
+            setState(() {
+              _setupGame();
+            });
+          }
+        });
+      } else {
+        // Check if all non-bug cells are revealed (win condition)
+        bool allNonBugsRevealed = true;
+        for (int i = 0; i < _isRevealed.length; i++) {
+          if (i != _bugPosition && !_isRevealed[i]) {
+            allNonBugsRevealed = false;
+            break;
+          }
+        }
+
+        if (allNonBugsRevealed) {
+          _gameOver = true;
+          // Show the bug position on win
+          _isRevealed[_bugPosition] = true;
+
+          // Schedule game reset after a delay
+          Future.delayed(const Duration(seconds: 2), () {
+            if (mounted) {
+              setState(() {
+                _setupGame();
+              });
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildRow(0, 4),
+            _buildRow(4, 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRow(
+    int start,
+    int end,
+  ) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(
+        end - start,
+        (index) {
+          final cellIndex = start + index;
+          return IconButton(
+            onPressed: () => _handleCellTap(cellIndex),
+            isSelected: _isRevealed[cellIndex],
+            color: _isRevealed[cellIndex]
+                ? cellIndex == _bugPosition
+                    ? bugColor
+                    : selectedColor
+                : unselectedColor,
+            icon: _isRevealed[cellIndex]
+                ? Icon(cellIndex == _bugPosition ? bugIcon : codeIcon)
+                : const Icon(hiddenIcon),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/components/showcase_section.dart
+++ b/lib/components/showcase_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class ShowcaseSection extends StatelessWidget {
-  const ShowcaseSection({
+class MaterialShowcaseSection extends StatelessWidget {
+  const MaterialShowcaseSection({
     super.key,
     required this.title,
     required this.child,

--- a/lib/flutter_material_showcase.dart
+++ b/lib/flutter_material_showcase.dart
@@ -22,57 +22,63 @@ import 'package:flutter_material_showcase/components/texts.dart';
 /// The [tabBackgroundColor] will default to [Colors.black26] if not set.
 class MaterialShowcase extends StatelessWidget {
   /// Creates a MaterialShowcase
-  const MaterialShowcase({super.key});
+  const MaterialShowcase({
+    super.key,
+    this.customSections = const [],
+  });
+
+  final List<MaterialShowcaseSection> customSections;
 
   @override
   Widget build(BuildContext context) {
-    return const DefaultTabController(
+    return DefaultTabController(
       length: 3,
       child: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            ShowcaseSection(
+            ...customSections,
+            const MaterialShowcaseSection(
               title: 'Buttons',
               child: MaterialShowcaseButtons(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Icon Buttons',
               child: MaterialShowcaseIconButtons(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Chips',
               child: MaterialShowcaseChips(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Selection Controls',
               child: MaterialShowcaseSelectionControls(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Text Inputs',
               child: MaterialShowcaseTextInputs(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Tabs',
               child: MaterialShowcaseTabs(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Bottom Navigation',
               child: MaterialShowcaseBottomNavigation(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Cards',
               child: MaterialShowcaseCards(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Date & Time Pickers',
               child: MaterialShowcaseDateTimePickers(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Dialogs',
               child: MaterialShowcaseDialogs(),
             ),
-            ShowcaseSection(
+            const MaterialShowcaseSection(
               title: 'Texts',
               child: MaterialShowcaseTexts(),
             ),


### PR DESCRIPTION
This pull request introduces following changes

**Changelog:**

- **Feature**: Added an option to add custom widget sections in showcase, along with other widgets
- **Example**: Introduced a Minesweeper-like custom widget in example app to demonstrate the functionality of custom sections.

**Notion behind this feature:**
- Some projects require to build custom widgets based on the current app theme, such as custom form elements or controls
- We already had `ShowcaseSection` widget exposed that displays `Title` & `Widget`, so I thought let's take a `List<ShowcaseSection>` as input to `MaterialShowcase` and add it with the list of default material widgets
- The reason why we display custom widgets at top (as opposed to conventionally bottom) is because theme based custom widgets are mostly built after configuring theme, that means the developer would like to view the custom widgets more than the built-in widgets (priorities 😉)
- This way, the showcase maintains it's structure and also offers flexibility

**Preview:**

<img src="https://github.com/user-attachments/assets/3964b468-c5c9-475f-bc62-2786dbf4f32d" alt="Screenshot" width="30%">

